### PR TITLE
Update to 3.0.1 and change imports -> import

### DIFF
--- a/docs/cross-reference.md
+++ b/docs/cross-reference.md
@@ -16,13 +16,13 @@ It is frequently desired (and necessary) to reference an SPDX 3
 [Element][Class_Element] that lives in one document from another. Since SPDX
 documents are valid [JSON-LD][JSON_LD] documents, linking elements together can
 be as simple as referencing the spdxId of one element from another (in the same
-way that doing so within a document links Elements together. For example,
+way that doing so within a document links Elements together). For example,
 assume we have this document that contains a [Person][Class_Person] we want to
 reference in another document:
 
 ```json
 {
-    "@context": "https://spdx.org/rdf/3.0.0/spdx-context.jsonld",
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
     "@graph": [
         {
             "type": "Person",
@@ -40,7 +40,7 @@ reference in another document:
         {
             "type": "CreationInfo",
             "@id": "_:creationinfo",
-            "specVersion": "3.0.0",
+            "specVersion": "3.0.1",
             "createdBy": [
                 "https://spdx.org/spdxdocs/Person/JoshuaWatt-0ef7e15a-5628-4bd9-8485-a3eace6dcc4f"
             ],
@@ -69,12 +69,12 @@ was also written by the same person, we can reference it in the creation info
 ```json
 ---
 {
-    "@context": "https://spdx.org/rdf/3.0.0/spdx-context.jsonld",
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
     "@graph": [
         {
             "type": "CreationInfo",
             "@id": "_:creationinfo1",
-            "specVersion": "3.0.0",
+            "specVersion": "3.0.1",
             "createdBy": [
                 "https://spdx.org/spdxdocs/Person/JoshuaWatt-0ef7e15a-5628-4bd9-8485-a3eace6dcc4f"
             ],
@@ -89,7 +89,7 @@ information that SPDX requires you to specify. Namely, since spdxIds are _not_
 necessarily resolvable URLs, this gives no indication as to where the
 [Person][Class_Person] can be found. In order to provide this information, SPDX
 requires that all externally referenced spdxIds be enumerated in the
-[imports][Property_imports] property of the local
+[import][Property_import] property of the local
 [SpdxDocument][Class_SpdxDocument]. Lets start by writing the preamble for the
 SpdxDocument:
 
@@ -102,10 +102,10 @@ SpdxDocument:
                 "core",
                 "software"
             ],
-            "imports": [
+            "import": [
 ```
 
-The [imports][Property_imports] property is a list of
+The [import][Property_import] property is a list of
 [ExternalMap][Class_ExternalMap] objects, one for each external spdxId being
 referenced. The class has one required property called
 [externalSpdxId][Property_externalSpdxId] which is the external spdxId being
@@ -153,7 +153,7 @@ class, it is also recommended:
 ```
 
 It should be noted that it is reasonable for the `definingArtifact` itself to
-be an external spdxId, as long as it also has the relevant entry in `imports`.
+be an external spdxId, as long as it also has the relevant entry in `import`.
 
 We also need to add an import for the [SpdxDocument][Class_SpdxDocument] that
 contains the author, as we will be referencing it later, so lets do that now:
@@ -231,17 +231,17 @@ needed to import it earlier:
 
 Happy Linking!
 
-[Class_Artifact]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Artifact
-[Class_Element]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Element
-[Class_ExternalMap]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/ExternalMap
-[Class_IntegrityMethod]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/IntegrityMethod
-[Class_Person]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Person
-[Class_SpdxDocument]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/SpdxDocument
-[Class_Relationship]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Relationship
+[Class_Artifact]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Artifact/
+[Class_Element]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Element/
+[Class_ExternalMap]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/ExternalMap/
+[Class_IntegrityMethod]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/IntegrityMethod/
+[Class_Person]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Person/
+[Class_SpdxDocument]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/SpdxDocument/
+[Class_Relationship]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/Relationship/
 [JSON_LD]: https://json-ld.org/
-[Property_createdBy]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/createdBy
-[Property_definingArtifact]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/definingArtifact
-[Property_externalSpdxId]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/externalSpdxId
-[Property_imports]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/imports
-[Property_verifiedUsing]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/verifiedUsing
-[Property_locationHint]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/locationHint
+[Property_createdBy]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/createdBy/
+[Property_definingArtifact]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/definingArtifact/
+[Property_externalSpdxId]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/externalSpdxId/
+[Property_import]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/import/
+[Property_verifiedUsing]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/verifiedUsing/
+[Property_locationHint]: https://spdx.github.io/spdx-spec/v3.0/model/Core/Properties/locationHint/


### PR DESCRIPTION
"imports" in 3.0.0 is now "import" in 3.0.1
This PR is updating the Cross reference document to reflect that.

Note: If example validation is required (in case that #14 already got merged before this one),
these two should be ready before merge
- [x] 3.0.1 IRIs (ready now)
- [x] new version of shacl2code is ready on PyPI (ready now - 0.0.14)